### PR TITLE
Add invite functionality to ProximityManager and UI

### DIFF
--- a/OSM/Manager/ProximityManager.swift
+++ b/OSM/Manager/ProximityManager.swift
@@ -229,6 +229,13 @@ class ProximityManager: NSObject, ObservableObject, CBCentralManagerDelegate, MC
         browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)  // Log invitation attempts
     }
 
+    /// Invite a peer to join the current session.
+    /// - Parameter peerID: The peer identifier to invite.
+    public func invite(_ peerID: MCPeerID) {
+        print("Inviting \(peerID.displayName)")
+        browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
+    }
+
      // MARK: - Message Handling
     func sendMessage(_ message: String) {
         guard !message.isEmpty else { return }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -153,15 +153,9 @@ struct SelectedUserProfileView: View {
     }
     
     private func sendInvite() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            let success = Bool.random()
-            if success {
-                inviteStatus = .pending
-            } else {
-                isShowingError = true
-                errorMessage = "Failed to send invite. Please try again."
-            }
-        }
+        let peerID = MCPeerID(displayName: user.name)
+        ProximityManager.shared.invite(peerID)
+        inviteStatus = .pending
     }
     
     private func sendMessage() {

--- a/Views/InviteView.swift
+++ b/Views/InviteView.swift
@@ -38,8 +38,9 @@ struct InviteView: View {
     }
 
     func sendInvite() {
-        // Add your invitation logic here. This could be sending a message or using the MultipeerConnectivity framework to send the invite.
-        // This is just a placeholder function.
-        isInviteSent = true
+        if let peer = peer {
+            ProximityManager.shared.invite(peer.peerID)
+            isInviteSent = true
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `invite(_:)` helper in `ProximityManager`
- send invites from `InviteView` via `ProximityManager`
- call the invite helper from the placeholder in `ContentView`

## Testing
- `swiftc -typecheck Views/InviteView.swift` *(fails: no such module 'SwiftUI')*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686ae0aae70c833081b60363475d5447