### PR TITLE
Allow model configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # OSM
+
+## OpenAI API Key
+
+The app uses the OpenAI API in `Views/OpenAIAPI.swift`. The API key is not stored in the source code. Provide your key at runtime using the `OPENAI_API_KEY` environment variable or by adding an `OPENAI_API_KEY` entry to the application's `Info.plist`.
+
+The OpenAI model can also be configured via an `OPENAI_MODEL` environment variable or `OPENAI_MODEL` key in `Info.plist`. If no value is provided, the code defaults to the modern `gpt-3.5-turbo` model.


### PR DESCRIPTION
## Summary
- make the OpenAI model configurable via an environment variable or Info.plist
- switch the API call to the chat/completions endpoint
- document the `OPENAI_MODEL` configuration

## Testing
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_686ae0dfb8988330bfe970c995e2b324