### PR TITLE
Fix peer connection

### DIFF
--- a/Views/ExploringView.swift
+++ b/Views/ExploringView.swift
@@ -64,9 +64,17 @@ struct ExploringView: View {
                                 .padding()
                         } else {
                             List {
-                                // Display connected peers in a List with swipe-to-refresh
                                 ForEach(proximityManager.connectedPeers, id: \.peerID) { peer in
-                                    Text(peer.peerID.displayName)
+                                    HStack {
+                                        Text(peer.peerID.displayName)
+                                        Spacer()
+                                        Button("Invite") {
+                                            proximityManager.invite(peer.peerID)
+                                        }
+                                        Button("Message") {
+                                            selectedPeer = peer
+                                        }
+                                    }
                                 }
                             }
                             .refreshable {
@@ -109,6 +117,10 @@ struct ExploringView: View {
                                 }
                             }
                         }
+                }
+                // Show MessagingView when a peer is selected
+                .sheet(item: $selectedPeer) { peer in
+                    MessagingView(peer: peer)
                 }
 
                 .onAppear {


### PR DESCRIPTION
## Summary
- only record found peers without auto-inviting them
- show Invite and Message buttons in Exploring view
- allow opening MessagingView from Exploring view

## Testing
- `swiftformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874118eb1548330a58509dc25a9545b